### PR TITLE
TT-2695 - Collection crumbs do not show if parent and shallow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# InferredCrumpets
+
+## 0.2.0
+
+* Fix: shallow routes no longer cause a routing error
+* Change: collection crumb not shown if a parent is set and the collection is shallow routed
+
+## 0.1.2
+
+* Fix: non-index collection actions now work
+
+## 0.1.1
+
+* Update: works with Crumpet 0.3.0
+
+## 0.1.0
+
+* Initial release

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -42,6 +42,8 @@ module InferredCrumpets
     end
 
     def build_crumb_for_collection!
+      return if parents.present? && shallow?
+
       if subject.is_a?(ActiveRecord::Relation)
         view_context.crumbs.add_crumb subject_name.pluralize.titleize
       elsif subject.is_a?(ActiveRecord::Base)
@@ -69,13 +71,13 @@ module InferredCrumpets
 
     def url_for_subject
       return unless can_route?(:show, id: subject.id)
-      view_context.url_for(shallow? ? subject : subject_with_parents)
+      view_context.url_for(shallow? ? transformed_subject : subject_with_parents)
     end
 
     def url_for_collection
       return view_context.objects_path if view_context.objects_path.present?
       return unless can_route?(:index)
-      view_context.url_for(class_with_parents)
+      view_context.url_for(shallow? ? transformed_subject.class : class_with_parents)
     end
 
     def subject_requires_transformation?
@@ -89,7 +91,7 @@ module InferredCrumpets
     end
 
     def shallow?
-      view_context.url_for(subject)
+      view_context.url_for(transformed_subject)
     rescue NoMethodError
       false
     end

--- a/lib/inferred_crumpets/version.rb
+++ b/lib/inferred_crumpets/version.rb
@@ -1,3 +1,3 @@
 module InferredCrumpets
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe InferredCrumpets::ViewHelpers do
       allow(view_context).to receive(:collection_url) { nil }
 
       allow(view_context).to receive(:controller) { double(:controller, :show => nil) }
-      allow(view_context).to receive(:url_for).with([user_class]).and_return('/users')
+      allow(view_context).to receive(:url_for).with(user_class).and_return('/users')
       allow(view_context).to receive(:url_for).with(users).and_return('/users')
       allow(view_context).to receive(:url_for).with(action: :index, controller: 'users').and_return('/users')
       allow(view_context).to receive(:url_for).with(user).and_return('/users/1')


### PR DESCRIPTION
**Why**

The collection crumb for the subject should not be shown if it a shallow route and the parent is specified. Additionally the logic for checking for shallow routes was broken in the case where the subject required transformation.

**Testing**

1. Visit a page that is a shallow route with a parent.