### PR TITLE
Tt 3102 breadcrumb regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+## 0.2.2
+
+* [TT-3102] Fix: Show subject crumb even when action is not linkable
+
 ## 0.2.1
 
 * [TT-2850] Fix: Don't link to actions that have no url

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -52,16 +52,15 @@ module InferredCrumpets
     end
 
     def build_crumb_for_action!
-      return unless linkable?
       return unless subject.is_a?(ActiveRecord::Base)
 
-      if %w(new create).include?(action)
+      if %w(new create).include?(action) && linkable?
         view_context.crumbs.add_crumb('New', wrapper_options: { class: 'active' })
         return
       end
 
       build_crumb_for_subject!
-      if %w(edit update).include?(action)
+      if %w(edit update).include?(action) && linkable?
         view_context.crumbs.add_crumb('Edit', wrapper_options: { class: 'active' })
       end
     end


### PR DESCRIPTION
### Why
Previous fix caused an issue where non-linkable actions would not have a crumb to there parent