### PR TITLE
Tt 3117 fix no method error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+## Unreleased
+
+* [TT-3117] Fix: NoMethodError when subject is not linkable
+
 ## 0.2.2
 
 * [TT-3102] Fix: Show subject crumb even when action is not linkable

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -54,13 +54,13 @@ module InferredCrumpets
     def build_crumb_for_action!
       return unless subject.is_a?(ActiveRecord::Base)
 
-      if %w(new create).include?(action) && linkable?
+      if %w(new create).include?(action)
         view_context.crumbs.add_crumb('New', wrapper_options: { class: 'active' })
         return
       end
 
       build_crumb_for_subject!
-      if %w(edit update).include?(action) && linkable?
+      if %w(edit update).include?(action)
         view_context.crumbs.add_crumb('Edit', wrapper_options: { class: 'active' })
       end
     end
@@ -70,7 +70,7 @@ module InferredCrumpets
     end
 
     def url_for_subject
-      return unless can_route?(:show, id: subject.id)
+      return unless can_route?(:show, id: subject.id) && linkable?
       view_context.url_for(shallow? ? transformed_subject : subject_with_parents)
     end
 


### PR DESCRIPTION
## WHY

* This is not catch the no method error correctly before and hiding the action paths when it shouldn't be

## TESTING

* http://kis.test:3000/resources/1065
* http://stradbroke.test:3000/fare_basis_sets/203/fare_bases/429