### PR TITLE
Ru 145 catch rails 5 url generation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+## Unreleased
+
+* [RU-145] Check for the Rails 5 ActionController::UrlGenerationError
+
 ## 0.2.4
 
 * [TT-3102] Move url checking out into seperate class

--- a/lib/inferred_crumpets/route_checker.rb
+++ b/lib/inferred_crumpets/route_checker.rb
@@ -17,6 +17,8 @@ module InferredCrumpets
       }.merge(params))
     rescue ActionController::RoutingError
       false
+    rescue ActionController::UrlGenerationError
+      false
     end
   end
 end

--- a/lib/inferred_crumpets/route_checker.rb
+++ b/lib/inferred_crumpets/route_checker.rb
@@ -15,9 +15,9 @@ module InferredCrumpets
         action:     action,
         controller: subject.class.table_name,
       }.merge(params))
-    rescue ActionController::RoutingError
+    rescue ActionController::RoutingError # Rails 3
       false
-    rescue ActionController::UrlGenerationError
+    rescue ActionController::UrlGenerationError # Rails 4+
       false
     end
   end


### PR DESCRIPTION
We need to check for the new `ActionController::UrlGenerationError` thrown by Rails 5