### PR TITLE
Add ability to link to all action types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+##  Unreleased
+
+* [TT-5088] Add ability to link to all actions
+
 ## 0.2.6
 
 * [TT-4479] Added grandparent support

--- a/lib/inferred_crumpets.rb
+++ b/lib/inferred_crumpets.rb
@@ -3,5 +3,6 @@ require "inferred_crumpets/builder"
 require "inferred_crumpets/railtie"
 require "inferred_crumpets/version"
 require "inferred_crumpets/view_helpers"
+require "inferred_crumpets/action_processor"
 
 module InferredCrumpets; end

--- a/lib/inferred_crumpets/action_processor.rb
+++ b/lib/inferred_crumpets/action_processor.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module InferredCrumpets
+  class ActionProcessor
+    NEW_ACTIONS = %w[new create].freeze
+    private_constant :NEW_ACTIONS
+
+    EDIT_ACTIONS = %w[edit update].freeze
+    private_constant :EDIT_ACTIONS
+
+    IGNORED_ACTIONS = %w[show].freeze
+    private_constant :IGNORED_ACTIONS
+
+    NEW_LABEL = 'New'
+    private_constant :NEW_LABEL
+
+    EDIT_LABEL = 'Edit'
+    private_constant :EDIT_LABEL
+
+    def self.for_action(action)
+      new(action).call
+    end
+
+    def initialize(action)
+      @action = action
+    end
+
+    def call
+      return build_opts(nil) if IGNORED_ACTIONS.include?(@action)
+      return build_opts(NEW_LABEL, false) if NEW_ACTIONS.include?(@action)
+      return build_opts(EDIT_LABEL) if EDIT_ACTIONS.include?(@action)
+
+      build_opts(@action.humanize)
+    end
+
+    private
+
+    def build_opts(label, has_subject = true)
+      OpenStruct.new(label: label, has_subject?: has_subject)
+    end
+  end
+end

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -54,16 +54,13 @@ module InferredCrumpets
 
     def build_crumb_for_action!
       return unless subject.is_a?(ActiveRecord::Base)
+      crumb = ActionProcessor.for_action(action)
+      build_crumb_for_subject! if crumb.has_subject?
+      add_crumb(crumb.label) if crumb.label.present?
+    end
 
-      if %w(new create).include?(action)
-        view_context.crumbs.add_crumb('New', wrapper_options: { class: 'active' })
-        return
-      end
-
-      build_crumb_for_subject!
-      if %w(edit update).include?(action)
-        view_context.crumbs.add_crumb('Edit', wrapper_options: { class: 'active' })
-      end
+    def add_crumb(label)
+      view_context.crumbs.add_crumb(label, wrapper_options: { class: 'active' })
     end
 
     def build_crumb_for_subject!

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe InferredCrumpets::ViewHelpers do
           expect(subject).to eq '<ul class="breadcrumb"><li><a href="/users">Users</a></li><li><a href="/users/1">Alice</a></li><li class="active"><span>Edit</span></li></ul>'
         end
       end
+
+      context 'with a custom action' do
+        let(:action) { 'show_details' }
+
+        it 'should infer crumbs: Users / Alice / Show details' do
+          expect(subject).to eq '<ul class="breadcrumb"><li><a href="/users">Users</a></li><li><a href="/users/1">Alice</a></li><li class="active"><span>Show details</span></li></ul>'
+        end
+      end
     end
 
     context 'when can route to action but subject is not linkable' do
@@ -154,7 +162,7 @@ RSpec.describe InferredCrumpets::ViewHelpers do
         end
       end
 
-      context 'on show route' do
+      context 'on edit route' do
         let(:action) { 'edit' }
 
         it 'should infer crumbs: Users / Alice / Edit ' do


### PR DESCRIPTION
**WHY**

QuickTravel has actions other than show/edit/new/create that crumbs should be shown for. This change allows for that.