### PR TITLE
Tt 5835 fix name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+## Unreleased
+
+* [TT-5835] Fix crumb title for active record relation
+
 ## 0.4.0
 
 * [TT-5807] Use crumb title for the subject name

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -46,7 +46,7 @@ module InferredCrumpets
       return if parents.present? && linkable?
 
       if subject.is_a?(ActiveRecord::Relation)
-        view_context.crumbs.add_crumb subject_name.pluralize.titleize
+        view_context.crumbs.add_crumb relation_name.pluralize.titleize
       elsif subject.is_a?(ActiveRecord::Base)
         view_context.crumbs.add_crumb subject.class.table_name.titleize, url_for_collection
       end
@@ -105,6 +105,10 @@ module InferredCrumpets
 
     def action
       view_context.params[:action]
+    end
+
+    def relation_name
+      subject.respond_to?(:name) && subject.name.present? ? subject.name : subject.to_s
     end
 
     def subject_name

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -114,9 +114,5 @@ module InferredCrumpets
     def class_with_parents
       [parents.last, transformed_subject.class].compact
     end
-
-    def inherited_resources?
-      defined?(InheritedResources) && view_context.controller.responder == InheritedResources::Responder
-    end
   end
 end

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe InferredCrumpets::ViewHelpers do
       allow(user_class).to receive(:crumb_title).and_return(nil)
 
       allow(users).to receive(:class).and_return(user_class)
-      allow(users).to receive(:to_s).and_return('User')
+      allow(users).to receive(:name).and_return('Users')
 
       allow(user).to receive(:id).and_return(id)
       allow(user).to receive(:crumb_title).and_return(nil)


### PR DESCRIPTION
### WHY

Previous PR broke the naming for ActiveRecord relations, which is used for some collections.