### PR TITLE
Tt 6224 custom crumbs for activerecord base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # InferredCrumpets
 
+## 0.4.2 Unreleased
+
+* [TT-6224] ActiveRecord::Base subjects can now take a custom crumb name
+
 ## 0.4.1
 
 * [TT-5835] Fix crumb title for active record relation

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -46,10 +46,9 @@ module InferredCrumpets
       return if parents.present? && linkable?
 
       if subject.is_a?(ActiveRecord::Relation)
-        view_context.crumbs.add_crumb relation_name.pluralize.titleize
+        view_context.crumbs.add_crumb collection_title_crumb_name(subject, relation_name.pluralize.titleize)
       elsif subject.is_a?(ActiveRecord::Base)
-        crumb_name = subject.class.respond_to?(:collection_title) ? subject.class.collection_title : subject.class.table_name.titleize
-        view_context.crumbs.add_crumb crumb_name, url_for_collection
+        view_context.crumbs.add_crumb collection_title_crumb_name(subject, subject.class.table_name.titleize), url_for_collection
       end
     end
 
@@ -118,6 +117,10 @@ module InferredCrumpets
 
     def class_with_parents
       [parents.last, transformed_subject.class].compact
+    end
+
+    def collection_title_crumb_name(subject, default_name)
+      subject.class.respond_to?(:collection_title) ? subject.class.collection_title : default_name
     end
   end
 end

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -45,10 +45,12 @@ module InferredCrumpets
     def build_crumb_for_collection!
       return if parents.present? && linkable?
 
-      if subject.is_a?(ActiveRecord::Relation)
-        view_context.crumbs.add_crumb collection_title_crumb_name(subject, relation_name.pluralize.titleize)
+      if subject.class.respond_to?(:collection_title)
+        view_context.crumbs.add_crumb subject.class.collection_title, url_for_collection
+      elsif subject.is_a?(ActiveRecord::Relation)
+        view_context.crumbs.add_crumb relation_name.pluralize.titleize
       elsif subject.is_a?(ActiveRecord::Base)
-        view_context.crumbs.add_crumb collection_title_crumb_name(subject, subject.class.table_name.titleize), url_for_collection
+        view_context.crumbs.add_crumb subject.class.table_name.titleize, url_for_collection
       end
     end
 
@@ -117,10 +119,6 @@ module InferredCrumpets
 
     def class_with_parents
       [parents.last, transformed_subject.class].compact
-    end
-
-    def collection_title_crumb_name(subject, default_name)
-      subject.class.respond_to?(:collection_title) ? subject.class.collection_title : default_name
     end
   end
 end

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -48,7 +48,7 @@ module InferredCrumpets
       if subject.is_a?(ActiveRecord::Relation)
         view_context.crumbs.add_crumb relation_name.pluralize.titleize
       elsif subject.is_a?(ActiveRecord::Base)
-        crumb_name = subject.class.respond_to?(:breadcrumb) ? subject.class.breadcrumb : subject.class.table_name.titleize
+        crumb_name = subject.class.respond_to?(:collection_title) ? subject.class.collection_title : subject.class.table_name.titleize
         view_context.crumbs.add_crumb crumb_name, url_for_collection
       end
     end

--- a/lib/inferred_crumpets/builder.rb
+++ b/lib/inferred_crumpets/builder.rb
@@ -48,7 +48,8 @@ module InferredCrumpets
       if subject.is_a?(ActiveRecord::Relation)
         view_context.crumbs.add_crumb relation_name.pluralize.titleize
       elsif subject.is_a?(ActiveRecord::Base)
-        view_context.crumbs.add_crumb subject.class.table_name.titleize, url_for_collection
+        crumb_name = subject.class.respond_to?(:breadcrumb) ? subject.class.breadcrumb : subject.class.table_name.titleize
+        view_context.crumbs.add_crumb crumb_name, url_for_collection
       end
     end
 

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -516,8 +516,21 @@ RSpec.describe InferredCrumpets::ViewHelpers do
         allow(user_class).to receive(:collection_title).and_return('Special Collection Title')
       end
 
-      it 'should infer crumbs: Users' do
+      it 'should display the collection title' do
         expect(subject).to eq '<ul class="breadcrumb"><li><a href="/users">Special Collection Title</a></li><li class="active"><span>New</span></li></ul>'
+      end
+    end
+
+    context 'for a relation with collection_title' do
+      let(:action) { 'index' }
+
+      before do
+        allow(view_context).to receive(:collection).and_return(users)
+        allow(User).to receive(:collection_title).and_return('Another Special Collection Title')
+      end
+
+      it 'should infer crumbs: Users' do
+        expect(subject).to eq '<ul class="breadcrumb"><li><span>Another Special Collection Title</span></li></ul>'
       end
     end
   end

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -529,7 +529,7 @@ RSpec.describe InferredCrumpets::ViewHelpers do
         allow(User).to receive(:collection_title).and_return('Another Special Collection Title')
       end
 
-      it 'should infer crumbs: Users' do
+      it 'display the collection title' do
         expect(subject).to eq '<ul class="breadcrumb"><li><span>Another Special Collection Title</span></li></ul>'
       end
     end

--- a/spec/inferred_crumpets/view_helpers_spec.rb
+++ b/spec/inferred_crumpets/view_helpers_spec.rb
@@ -505,5 +505,20 @@ RSpec.describe InferredCrumpets::ViewHelpers do
         end
       end
     end
+
+    context 'when the subject has a collection_title' do
+      let(:action) { 'new' }
+      let(:new_record) { true }
+
+      before do
+        allow(view_context).to receive(:collection).and_return(users)
+        allow(view_context).to receive(:current_object).and_return(user)
+        allow(user_class).to receive(:collection_title).and_return('Special Collection Title')
+      end
+
+      it 'should infer crumbs: Users' do
+        expect(subject).to eq '<ul class="breadcrumb"><li><a href="/users">Special Collection Title</a></li><li class="active"><span>New</span></li></ul>'
+      end
+    end
   end
 end


### PR DESCRIPTION
Needed because `table_name` can create some unexpected issues when using tables from `empty_qt`